### PR TITLE
chore(middleware): pass auth secret to getToken to fix MissingSecret …

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -36,7 +36,7 @@ function resolveLocalePrefix(pathname: string): { prefix: string; hasLocale: boo
 
 async function nextAuthGuard(req: NextRequest, baseRes: NextResponse): Promise<NextResponse> {
   try {
-    const token = await getToken({ req });
+    const token = await getToken({ req, secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET });
     if (token?.isAdmin === true) {
       return baseRes;
     }


### PR DESCRIPTION
<!--
PULL REQUEST TEMPLATE

Thank you for contributing to our project! Please fill out the template below to help
reviewers understand your changes and their purpose.
-->

### Summary
Fix admin login redirect loop by explicitly passing the Auth secret to NextAuth’s getToken in the admin guard.

## Related Issues
- Fixes # (if applicable)

## Description
Middleware-based admin protection relied on `getToken({ req })`, which threw a MissingSecret error in the runtime and redirected users back to the sign-in page. This change injects the secret explicitly from `AUTH_SECRET` or `NEXTAUTH_SECRET`, ensuring token decoding works in middleware/edge contexts and allowing admins to access the dashboard once authenticated.

## Changes Made
- Update `middleware.ts` admin guard to call:
  - `getToken({ req, secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET })`

## Screenshots / Videos
N/A

## Type of Change
- [x] 🐛 Bug fix (non-breaking change addressing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🧪 Test addition or modification
- [ ] 🛠️ CI/CD infrastructure improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Code style/formatting update
- [ ] 🚀 Performance improvement

## Implementation Details
- Auth.js/NextAuth requires a secret when decoding JWTs in middleware. Even with `NEXTAUTH_SECRET` set, edge/runtime contexts may not automatically bind it to `getToken`. Passing `secret` ensures consistent behavior and aligns with Auth.js v5 requirements. Supports both `AUTH_SECRET` and `NEXTAUTH_SECRET`.

## Testing Instructions
1. Ensure `.env.local` contains `NEXTAUTH_SECRET` (or `AUTH_SECRET`) and restart the dev server.
2. Sign in via admin credentials.
3. Navigate to `/admin`; you should no longer be redirected to `/admin/auth/signin`.
4. Verify token contains `isAdmin: true` and the guard allows access.

## Deployment Notes
- Confirm `NEXTAUTH_SECRET` or `AUTH_SECRET` is set in the deployment environment.
- Ensure `NEXTAUTH_URL` matches the deployed URL.
- Restart application after updating environment variables.

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix is effective or my feature works
- [ ] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [ ] I have verified my changes in multiple browsers/environments (if applicable)
- [x] New and existing unit tests pass locally with my changes (N/A or covered)
- [ ] I have made corresponding changes to the documentation
- [x] My code follows the established code style of the project
- [ ] I have commented my code, particularly in hard-to-understand areas

## Additional Context
- Works with both `AUTH_SECRET` and `NEXTAUTH_SECRET`.
- No breaking changes; only affects middleware admin guard behavior.