### PR TITLE
fix(admin): resolve redirect loop in auth pages

### DIFF
--- a/app/[locale]/admin/layout.tsx
+++ b/app/[locale]/admin/layout.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { SessionProvider } from "next-auth/react";
 
 function AdminAuthGuard({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const hasRedirectedRef = useRef(false);
 
+  // Check if we're on an auth page (signin, signup, etc.)
+  const isAuthPage = pathname?.includes('/admin/auth/');
+
   useEffect(() => {
-    if (status === "loading" || hasRedirectedRef.current) return;
+    if (status === "loading" || hasRedirectedRef.current || isAuthPage) return;
 
     if (!session) {
       console.log("No session, redirecting to signin");
@@ -31,7 +35,7 @@ function AdminAuthGuard({ children }: { children: React.ReactNode }) {
     }
 
     console.log("User authenticated and is admin");
-  }, [session, status, router]);
+  }, [session, status, router, isAuthPage]);
 
   // Show loading while checking auth
   if (status === "loading") {
@@ -45,8 +49,8 @@ function AdminAuthGuard({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // Show loading while redirecting
-  if (!session || !session.user?.isAdmin) {
+  // Show loading while redirecting (but not on auth pages)
+  if (!isAuthPage && (!session || !session.user?.isAdmin)) {
     return (
       <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center">
         <div className="text-center">


### PR DESCRIPTION
## PR Description

### 🐛 **Bug Fix: Admin Auth Redirect Loop**

**Problem:**
Users visiting `/admin/auth/signin` get stuck in an infinite redirect loop, showing "Redirecting..." indefinitely. The browser console shows "No session, redirecting to signin" messages repeatedly.

**Root Cause:**
The `AdminAuthGuard` component in `app/[locale]/admin/layout.tsx` was applying authentication checks to ALL admin routes, including the signin page itself. This created a circular redirect:

1. User visits `/admin/auth/signin`
2. `AdminAuthGuard` detects no session
3. Redirects to `/admin/auth/signin` 
4. Triggers the same check again → infinite loop

**Solution:**
- Added pathname detection using `usePathname()` hook
- Created `isAuthPage` check for `/admin/auth/*` routes
- Modified `useEffect` to skip authentication checks on auth pages
- Updated loading/redirecting logic to handle auth pages properly

**Changes Made:**
- **File:** `app/[locale]/admin/layout.tsx`
  - Import `usePathname` from `next/navigation`
  - Add `isAuthPage` boolean check
  - Update `useEffect` dependency array and early return logic
  - Modify loading states to exclude auth pages

**Testing:**
- ✅ `/admin/auth/signin` - No longer stuck in redirect loop
- ✅ `/admin` (unauthenticated) - Still redirects to signin properly
- ✅ `/admin` (non-admin user) - Still redirects to dashboard properly  
- ✅ `/admin` (admin user) - Still loads admin panel properly
- ✅ `/auth/signin` - No impact (not under admin layout)

**Impact:**
- **Before:** Admin signin page completely inaccessible
- **After:** Admin signin page loads normally, authentication flow works as expected

**Type of Change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors or warnings
- [x] Manual testing completed
- [x] No unnecessary file changes

