### PR TITLE
Fix: Client Edit Modal Not Populating Existing Data

### DIFF
--- a/app/[locale]/admin/clients/page.tsx
+++ b/app/[locale]/admin/clients/page.tsx
@@ -897,7 +897,7 @@ export default function ClientsPage() {
       )}
 
       {/* Client Form Modal */}
-      {isOpen && (
+      {isOpen && (formMode === 'create' || (formMode === 'edit' && selectedClient)) && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center z-50 p-4 overflow-y-auto">
           <div className="w-full max-w-4xl my-8 bg-white dark:bg-gray-900 rounded-xl shadow-xl max-h-[calc(100vh-4rem)] overflow-y-auto">
             <ClientForm

--- a/components/admin/clients/client-form.tsx
+++ b/components/admin/clients/client-form.tsx
@@ -168,11 +168,8 @@ export function ClientForm({ client, onSubmit, onCancel, isLoading = false, mode
     }
   };
 
-  const handleInputChange = (field: string, value: string | boolean) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: field === 'accountType' ? value as 'individual' | 'business' | 'enterprise' : value
-    }));
+  const handleInputChange = (field: keyof typeof formData, value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value as any }));
 
     // Clear error when user starts typing
     if (errors[field]) {

--- a/components/admin/clients/client-form.tsx
+++ b/components/admin/clients/client-form.tsx
@@ -26,83 +26,30 @@ export function ClientForm({ client, onSubmit, onCancel, isLoading = false, mode
   const formClasses = "p-6 space-y-6";
   const actionsClasses = "flex justify-end space-x-3 pt-6 border-t border-gray-200 dark:border-gray-700 bg-gradient-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-900 -mx-6 -mb-6 px-6 pb-6";
 
-  const [formData, setFormData] = useState(() => {
-    if (client && mode === 'edit') {
-      return {
-        email: client.email || '',
-        displayName: client.displayName || '',
-        username: client.username || '',
-        bio: client.bio || '',
-        jobTitle: client.jobTitle || '',
-        company: client.company || '',
-        industry: client.industry || '',
-        phone: client.phone || '',
-        website: client.website || '',
-        location: client.location || '',
-        accountType: client.accountType || 'individual',
-        timezone: client.timezone || 'UTC',
-        language: client.language || 'en',
-      };
-    } else {
-      return {
-        email: '',
-        displayName: '',
-        username: '',
-        bio: '',
-        jobTitle: '',
-        company: '',
-        industry: '',
-        phone: '',
-        website: '',
-        location: '',
-        accountType: 'individual' as const,
-        timezone: 'UTC',
-        language: 'en',
-      };
-    }
+  // Helper function to construct form defaults based on client data and mode
+  const defaultsFor = (m: 'create' | 'edit', c?: ClientProfileWithAuth) => ({
+    email: m === 'edit' ? (c?.email ?? '') : '',
+    displayName: c?.displayName ?? '',
+    username: c?.username ?? '',
+    bio: c?.bio ?? '',
+    jobTitle: c?.jobTitle ?? '',
+    company: c?.company ?? '',
+    industry: c?.industry ?? '',
+    phone: c?.phone ?? '',
+    website: c?.website ?? '',
+    location: c?.location ?? '',
+    accountType: (c?.accountType ?? 'individual') as 'individual' | 'business' | 'enterprise',
+    timezone: c?.timezone ?? 'UTC',
+    language: c?.language ?? 'en',
   });
+
+  const [formData, setFormData] = useState(() => defaultsFor(mode, client));
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   // Update form data when client prop changes
   useEffect(() => {
-    if (client && mode === 'edit') {
-      const newFormData = {
-        email: client.email || '',
-        displayName: client.displayName || '',
-        username: client.username || '',
-        bio: client.bio || '',
-        jobTitle: client.jobTitle || '',
-        company: client.company || '',
-        industry: client.industry || '',
-        phone: client.phone || '',
-        website: client.website || '',
-        location: client.location || '',
-        accountType: client.accountType || 'individual',
-        timezone: client.timezone || 'UTC',
-        language: client.language || 'en',
-      };
-      setFormData(newFormData);
-    } else if (mode === 'create') {
-      // Reset form for create mode
-      const resetFormData = {
-        email: '',
-        displayName: '',
-        username: '',
-        bio: '',
-        jobTitle: '',
-        company: '',
-        industry: '',
-        phone: '',
-        website: '',
-        location: '',
-        accountType: 'individual' as const,
-        timezone: 'UTC',
-        language: 'en',
-      };
-      setFormData(resetFormData);
-    }
-    // Clear any existing errors when client changes
+    setFormData(defaultsFor(mode, client));
     setErrors({});
   }, [client, mode]);
 

--- a/components/admin/clients/client-form.tsx
+++ b/components/admin/clients/client-form.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Save, X } from "lucide-react";
-import type { 
-  CreateClientRequest, 
+import type {
+  CreateClientRequest,
   UpdateClientRequest
 } from "@/lib/types/client";
 import type { ClientProfileWithAuth } from "@/lib/db/queries";
@@ -19,29 +19,92 @@ interface ClientFormProps {
 }
 
 export function ClientForm({ client, onSubmit, onCancel, isLoading = false, mode }: ClientFormProps) {
+  
   // Extract long className strings into constants for better maintainability
   const containerClasses = "w-full";
   const headerClasses = "px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-900";
   const formClasses = "p-6 space-y-6";
   const actionsClasses = "flex justify-end space-x-3 pt-6 border-t border-gray-200 dark:border-gray-700 bg-gradient-to-r from-gray-50 to-white dark:from-gray-800 dark:to-gray-900 -mx-6 -mb-6 px-6 pb-6";
 
-  const [formData, setFormData] = useState({
-    email: '',
-    displayName: client?.displayName || '',
-    username: client?.username || '',
-    bio: client?.bio || '',
-    jobTitle: client?.jobTitle || '',
-    company: client?.company || '',
-    industry: client?.industry || '',
-    phone: client?.phone || '',
-    website: client?.website || '',
-    location: client?.location || '',
-    accountType: client?.accountType || 'individual',
-    timezone: client?.timezone || 'UTC',
-    language: client?.language || 'en',
+  const [formData, setFormData] = useState(() => {
+    if (client && mode === 'edit') {
+      return {
+        email: client.email || '',
+        displayName: client.displayName || '',
+        username: client.username || '',
+        bio: client.bio || '',
+        jobTitle: client.jobTitle || '',
+        company: client.company || '',
+        industry: client.industry || '',
+        phone: client.phone || '',
+        website: client.website || '',
+        location: client.location || '',
+        accountType: client.accountType || 'individual',
+        timezone: client.timezone || 'UTC',
+        language: client.language || 'en',
+      };
+    } else {
+      return {
+        email: '',
+        displayName: '',
+        username: '',
+        bio: '',
+        jobTitle: '',
+        company: '',
+        industry: '',
+        phone: '',
+        website: '',
+        location: '',
+        accountType: 'individual' as const,
+        timezone: 'UTC',
+        language: 'en',
+      };
+    }
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Update form data when client prop changes
+  useEffect(() => {
+    if (client && mode === 'edit') {
+      const newFormData = {
+        email: client.email || '',
+        displayName: client.displayName || '',
+        username: client.username || '',
+        bio: client.bio || '',
+        jobTitle: client.jobTitle || '',
+        company: client.company || '',
+        industry: client.industry || '',
+        phone: client.phone || '',
+        website: client.website || '',
+        location: client.location || '',
+        accountType: client.accountType || 'individual',
+        timezone: client.timezone || 'UTC',
+        language: client.language || 'en',
+      };
+      setFormData(newFormData);
+    } else if (mode === 'create') {
+      // Reset form for create mode
+      const resetFormData = {
+        email: '',
+        displayName: '',
+        username: '',
+        bio: '',
+        jobTitle: '',
+        company: '',
+        industry: '',
+        phone: '',
+        website: '',
+        location: '',
+        accountType: 'individual' as const,
+        timezone: 'UTC',
+        language: 'en',
+      };
+      setFormData(resetFormData);
+    }
+    // Clear any existing errors when client changes
+    setErrors({});
+  }, [client, mode]);
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -159,8 +222,11 @@ export function ClientForm({ client, onSubmit, onCancel, isLoading = false, mode
   };
 
   const handleInputChange = (field: string, value: string | boolean) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
-    
+    setFormData(prev => ({
+      ...prev,
+      [field]: field === 'accountType' ? value as 'individual' | 'business' | 'enterprise' : value
+    }));
+
     // Clear error when user starts typing
     if (errors[field]) {
       setErrors(prev => ({ ...prev, [field]: '' }));


### PR DESCRIPTION
###   Summary

  Fixed a critical issue where the client edit modal was opening but not displaying the existing client data in the form
  fields, making it impossible to edit client information effectively.

  ### Changes Made

  - Enhanced ClientForm initialization: Improved form data initialization logic to properly handle client data based on
  mode (create vs edit)
  - Fixed modal rendering condition: Added proper conditional rendering to ensure the modal only displays when
  selectedClient is available for edit mode
  - Improved state management: Enhanced useEffect dependencies and form data updates to properly react to client prop
  changes
  - TypeScript fixes: Resolved type errors for the accountType field handling

  ### Technical Details

  - Modified ClientForm component to use lazy state initialization for better performance
  - Added proper mode checking in form data initialization
  - Enhanced modal rendering logic in clients page to prevent premature rendering
  - Fixed type casting for enum values in form input handling

  ### Test Plan

  - Click edit button on any client row
  - Verify modal opens with existing client data populated in all form fields
  - Verify create client modal still works with empty form
  - Verify form validation and submission work correctly